### PR TITLE
vee-common: F*** you man, you are dead to us

### DIFF
--- a/vee-common.mk
+++ b/vee-common.mk
@@ -62,7 +62,6 @@ PRODUCT_COPY_FILES += frameworks/native/data/etc/handheld_core_hardware.xml:syst
 # Display HALS
 PRODUCT_PACKAGES += copybit.msm7x27a
 PRODUCT_PACKAGES += gralloc.msm7x27a
-PRODUCT_PACKAGES += hwcomposer.msm7x27a
 PRODUCT_PACKAGES += memtrack.msm7x27a
 PRODUCT_PACKAGES += libqdMetaData
 


### PR DESCRIPTION
The vsync is broken, and v1/vee3 not support to fake vsync.

This reverts commit 2a55882dc687459c146f67956fa5c41df248a381.
